### PR TITLE
update build_printable_address to send lines 1 - 5 only to PrintableA…

### DIFF
--- a/lib/postman_paf/rules/address_builder.rb
+++ b/lib/postman_paf/rules/address_builder.rb
@@ -15,7 +15,7 @@ module PostmanPAF
         lines.each_with_index do |line, index|
           line_number = index + 1
           line = line.to_s if line.is_a?(Integer)
-          printable_address.send("line#{line_number}=", line) unless line_number.eql?(6) || line_number.eql?(7)
+          printable_address.send("line#{line_number}=", line) if line_number >= 1 && line_number <= 5
         end
 
         printable_address.postcode = paf_address[POSTCODE].slice(0..7)

--- a/lib/postman_paf/version.rb
+++ b/lib/postman_paf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PostmanPAF
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/fixtures/addresses.json
+++ b/spec/fixtures/addresses.json
@@ -2988,6 +2988,39 @@
           "dps": "1A"
         }
       },
+      "All Expected Elements": {
+        "paf": {
+          "uprn": "111111",
+          "udprn": "1111111",
+          "poBoxNumber": "dummy_poBoxNumber",
+          "organisationName": "dummy organisationName",
+          "departmentName": "dummy departmentName",
+          "subBuildingName": "dummy subBuildingName",
+          "buildingName": "MAIN BUILDING",
+          "buildingNumber": "11",
+          "dependentThoroughfareName": "LONG VIEW ROAD",
+          "thoroughfareName": "dummy thoroughfareName",
+          "doubleDependentLocality": "dummy doubleDependentLocality",
+          "dependentLocality": "MORRISTON",
+          "postTown": "SWANSEA",
+          "postcode": "SA99 1AA",
+          "dps": "1A",
+          "mailsort": "dummy-mailsort",
+          "language": "EN",
+          "country": "UNITED KINGDOM"
+        },
+        "printable": {
+          "line1": "dummy organisationName",
+          "line2": "dummy departmentName",
+          "line3": "PO BOX dummy_poBoxNumber",
+          "line4": "dummy subBuildingName",
+          "line5": "SWANSEA",
+          "postcode": "SA99 1AA",
+          "country": "UNITED KINGDOM",
+          "language": "EN",
+          "dps": "1A"
+        }
+      },
       "Exception i Sub Building Name": {
         "paf": {
           "poBoxNumber": null,


### PR DESCRIPTION
Bugfix for cases where large amount of PAF address data results in more than 7 converted address lines