### PR TITLE
Rule3 exception ii no thoroughfare name with dependent locality only

### DIFF
--- a/lib/postman_paf/rules/rule_3.rb
+++ b/lib/postman_paf/rules/rule_3.rb
@@ -19,7 +19,9 @@ module PostmanPAF
 
         case exception
         when :exception_i, :exception_ii, :exception_iii
-          if paf_address[DEPENDENT_THOROUGHFARE_NAME]
+          if paf_address[THOROUGHFARE_NAME].nil? && paf_address[DEPENDENT_LOCALITY]
+            data << "#{paf_address[BUILDING_NAME]} #{paf_address[DEPENDENT_LOCALITY]}"
+          elsif paf_address[DEPENDENT_THOROUGHFARE_NAME]
             data << "#{paf_address[BUILDING_NAME]} #{paf_address[DEPENDENT_THOROUGHFARE_NAME]}"
             data << paf_address[THOROUGHFARE_NAME]
           else
@@ -37,7 +39,9 @@ module PostmanPAF
         end
 
         data << paf_address[DOUBLE_DEPENDENT_LOCALITY] unless data.include?(paf_address[DOUBLE_DEPENDENT_LOCALITY])
-        data << paf_address[DEPENDENT_LOCALITY] unless data.include?(paf_address[DEPENDENT_LOCALITY])
+        unless data.include?("#{paf_address[BUILDING_NAME]} #{paf_address[DEPENDENT_LOCALITY]}") || data.include?(paf_address[DEPENDENT_LOCALITY])
+          data << paf_address[DEPENDENT_LOCALITY]
+        end
         data
       end
     end

--- a/lib/postman_paf/version.rb
+++ b/lib/postman_paf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PostmanPAF
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/fixtures/addresses.json
+++ b/spec/fixtures/addresses.json
@@ -1045,6 +1045,33 @@
           "dps": "1A"
         }
       },
+      "Exception ii No Thoroughfare Name With Dependent Locality Only": {
+        "paf": {
+          "poBoxNumber": null,
+          "organisationName": null,
+          "departmentName": null,
+          "subBuildingName": null,
+          "buildingName": "51A",
+          "buildingNumber": null,
+          "dependentThoroughfareName": null,
+          "thoroughfareName": null,
+          "doubleDependentLocality": null,
+          "dependentLocality": "dependentLocality",
+          "postTown": "postTown",
+          "postcode": "SA99 1BN",
+          "dps": "1A",
+          "language": "EN",
+          "country": "Wales"
+        },
+        "printable": {
+          "line1": "51A dependentLocality",
+          "line5": "postTown",
+          "postcode": "SA99 1BN",
+          "country": "Wales",
+          "language": "EN",
+          "dps": "1A"
+        }
+      },
       "Exception ii No Dependent Thoroughfare": {
         "paf": {
           "poBoxNumber": null,

--- a/spec/fixtures/addresses.json
+++ b/spec/fixtures/addresses.json
@@ -986,6 +986,33 @@
           "dps": "1A"
         }
       },
+      "Exception i No Thoroughfare Name With Dependent Locality Only": {
+        "paf": {
+          "poBoxNumber": null,
+          "organisationName": null,
+          "departmentName": null,
+          "subBuildingName": null,
+          "buildingName": "1 buildingName 4",
+          "buildingNumber": null,
+          "dependentThoroughfareName": null,
+          "thoroughfareName": null,
+          "doubleDependentLocality": null,
+          "dependentLocality": "dependentLocality",
+          "postTown": "postTown",
+          "postcode": "SA99 1BN",
+          "dps": "1A",
+          "language": "EN",
+          "country": "Wales"
+        },
+        "printable": {
+          "line1": "1 buildingName 4 dependentLocality",
+          "line5": "postTown",
+          "postcode": "SA99 1BN",
+          "country": "Wales",
+          "language": "EN",
+          "dps": "1A"
+        }
+      },
       "Exception i No Dependent Thoroughfare": {
         "paf": {
           "poBoxNumber": null,
@@ -1124,6 +1151,33 @@
           "line2": "thoroughfareName",
           "line3": "doubleDependentLocality",
           "line4": "dependentLocality",
+          "line5": "postTown",
+          "postcode": "SA99 1BN",
+          "country": "Wales",
+          "language": "EN",
+          "dps": "1A"
+        }
+      },
+      "Exception iii No Thoroughfare Name With Dependent Locality Only": {
+        "paf": {
+          "poBoxNumber": null,
+          "organisationName": null,
+          "departmentName": null,
+          "subBuildingName": null,
+          "buildingName": "A",
+          "buildingNumber": null,
+          "dependentThoroughfareName": null,
+          "thoroughfareName": null,
+          "doubleDependentLocality": null,
+          "dependentLocality": "dependentLocality",
+          "postTown": "postTown",
+          "postcode": "SA99 1BN",
+          "dps": "1A",
+          "language": "EN",
+          "country": "Wales"
+        },
+        "printable": {
+          "line1": "A dependentLocality",
           "line5": "postTown",
           "postcode": "SA99 1BN",
           "country": "Wales",


### PR DESCRIPTION
Add logic to handle rule3 (buildingName only) exception i, ii, or iii addresses containing no thoroughfareName and dependentLocality only
Add unit test coverage